### PR TITLE
fix: Syntax error when using default export - filters.md

### DIFF
--- a/sources/@roots/wordpress-hmr/docs/usage/filters.md
+++ b/sources/@roots/wordpress-hmr/docs/usage/filters.md
@@ -56,16 +56,17 @@ export default {
   hook: `blocks.registerBlockType`,
   /** Filter callback */
   callback: (settings, name) => {
-  if (name !== 'core/list') return settings;
+    if (name !== 'core/list') return settings;
 
-  return assign({}, settings, {
-    example: {
-      innerBlocks: [
-        {name: 'core/list-item', attributes: {content: 'Item a'}},
-        {name: 'core/list-item', attributes: {content: 'Item b'}},
-      ],
-    },
-  })
+    return assign({}, settings, {
+      example: {
+        innerBlocks: [
+          {name: 'core/list-item', attributes: {content: 'Item a'}},
+          {name: 'core/list-item', attributes: {content: 'Item b'}},
+        ],
+      },
+    })
+  }
 }
 ```
 


### PR DESCRIPTION
Document에서 예제 코드를 복사에서 사용하려하는데 구문 오류가있었다.

There was a syntax error trying to use example code in copy in Document.